### PR TITLE
chore: add workspace support

### DIFF
--- a/oort3.code-workspace
+++ b/oort3.code-workspace
@@ -1,0 +1,16 @@
+{
+  "folders": [
+    {
+      "path": "shared"
+    },
+    {
+      "path": "services"
+    },
+    {
+      "path": "frontend"
+    }
+  ],
+  "settings": {
+    "git.openRepositoryInParentFolders": "always"
+  }
+}


### PR DESCRIPTION
rust-analyzer in VSCode doesn't work for frontend/ because root workspace does not include them.
