### PR TITLE
Add a button to start the replay paused

### DIFF
--- a/frontend/app/src/editor_window.rs
+++ b/frontend/app/src/editor_window.rs
@@ -281,6 +281,10 @@ impl Component for EditorWindow {
             .props()
             .on_editor_action
             .reform(|_| "oort-replay".to_string());
+        let replay_paused_cb = context
+            .props()
+            .on_editor_action
+            .reform(|_| "oort-replay-paused".to_string());
         let cmd_or_ctrl = if is_mac() { "Cmd" } else { "Ctrl" };
 
         create_portal(
@@ -299,6 +303,11 @@ impl Component for EditorWindow {
                         class="material-symbols-outlined"
                         title={format!("Replay ({cmd_or_ctrl}-Shift-Enter)")}
                     >{ "replay" }</span></div>
+                    <div class="replay_button_paused"><span
+                        onclick={replay_paused_cb}
+                        class="material-symbols-outlined"
+                        title={format!("Replay paused")}
+                    >{ "autopause" }</span></div>
                 </>
             },
             context.props().host.clone(),
@@ -374,6 +383,8 @@ impl Component for EditorWindow {
                             | monaco::sys::KeyCode::Enter as u32,
                     ),
                 );
+
+                add_action("oort-replay-paused", "Replay paused", None);
 
                 add_action("oort-restore-initial-code", "Restore initial code", None);
 

--- a/frontend/app/src/simulation_window.rs
+++ b/frontend/app/src/simulation_window.rs
@@ -12,6 +12,7 @@ use yew_agent::{Bridge, Bridged};
 pub enum Msg {
     StartSimulation {
         scenario_name: String,
+        start_paused: bool,
         seed: u32,
         codes: Vec<Code>,
     },
@@ -78,6 +79,7 @@ impl Component for SimulationWindow {
             Msg::StartSimulation {
                 scenario_name,
                 seed,
+                start_paused,
                 codes,
             } => {
                 self.nonce = rand::thread_rng().gen();
@@ -88,6 +90,7 @@ impl Component for SimulationWindow {
                     self.canvas_ref.clone(),
                     self.status_ref.clone(),
                     self.picked_ref.clone(),
+                    start_paused,
                 )));
                 self.sim_agent
                     .send(oort_simulation_worker::Request::StartScenario {

--- a/frontend/app/src/ui/mod.rs
+++ b/frontend/app/src/ui/mod.rs
@@ -63,6 +63,7 @@ impl UI {
         canvas_ref: NodeRef,
         status_ref: NodeRef,
         picked_ref: NodeRef,
+        paused: bool,
     ) -> Self {
         if let Some(elem) = status_ref.cast::<Element>() {
             elem.set_text_content(Some("LOADING..."));
@@ -76,7 +77,6 @@ impl UI {
         let camera_target = point![0.0, 0.0];
         renderer.set_view(zoom, point![camera_target.x, camera_target.y]);
         let frame_timer: frame_timer::FrameTimer = Default::default();
-        let paused = false;
         let single_steps = 0;
 
         let keys_down = std::collections::HashSet::<String>::new();
@@ -183,7 +183,8 @@ impl UI {
             self.physics_time += elapsed;
         }
 
-        if self.status == Status::Running && (!self.paused || self.single_steps > 0 || fast_forward)
+        if self.status == Status::Running
+            && (!self.paused || self.single_steps > 0 || fast_forward || self.snapshot.is_none())
         {
             let dt = std::time::Duration::from_secs_f64(simulation::PHYSICS_TICK_LENGTH);
             if fast_forward {

--- a/frontend/app/style.css
+++ b/frontend/app/style.css
@@ -64,6 +64,21 @@ body {
   color: #aaaaaa;
 }
 
+.replay_button_paused {
+  width: 30px;
+  height: 30px;
+  right: 29px;
+  top: 90px;
+  position: absolute;
+}
+
+.replay_button_paused span {
+  font-size: 36px;
+  cursor: pointer;
+  text-shadow: 1px 1px #444444;
+  color: #aaaaaa;
+}
+
 .glcanvas {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
I found it frustrating to debug problems that happen in the first few ticks of simulation. This allows users to step through the first ticks, without having to quickly pause.