### PR TITLE
Enable editor action hotkeys in sim

### DIFF
--- a/frontend/app/src/documentation.rs
+++ b/frontend/app/src/documentation.rs
@@ -28,6 +28,8 @@ pub fn documentation(props: &DocumentationProps) -> Html {
                 <li>{ "N: Single-step (advance time by one tick and then pause)." }</li>
                 <li>{ "F: Fast-forward." }</li>
                 <li>{ "M: Slow motion." }</li>
+                <li>{ "R: Restart." }</li>
+                <li>{ "P: Restart and pause." }</li>
                 <li>{ "G: Show debug lines for all ships." }</li>
                 <li>{ "C: Chase, or follow the selected ship." }</li>
                 <li>{ "V: Toggle NLIPS, which makes smaller ships more visible when zoomed out." }</li>

--- a/frontend/app/src/documentation.rs
+++ b/frontend/app/src/documentation.rs
@@ -1,3 +1,4 @@
+use crate::editor_window::CMD_OR_CTRL;
 use yew::prelude::*;
 
 #[derive(Properties, PartialEq)]
@@ -28,14 +29,15 @@ pub fn documentation(props: &DocumentationProps) -> Html {
                 <li>{ "N: Single-step (advance time by one tick and then pause)." }</li>
                 <li>{ "F: Fast-forward." }</li>
                 <li>{ "M: Slow motion." }</li>
-                <li>{ "R: Restart." }</li>
-                <li>{ "P: Restart and pause." }</li>
                 <li>{ "G: Show debug lines for all ships." }</li>
                 <li>{ "C: Chase, or follow the selected ship." }</li>
                 <li>{ "V: Toggle NLIPS, which makes smaller ships more visible when zoomed out." }</li>
                 <li>{ "B: Toggle postprocessing (blur)." }</li>
                 <li>{ "Mouse wheel: Zoom." }</li>
                 <li>{ "Mouse click: Select a ship to show debugging info." }</li>
+                <li>{ format!("{CMD_OR_CTRL}-Enter: Execute") }</li>
+                <li>{ format!("{CMD_OR_CTRL}-Shift-Enter: Replay") }</li>
+                <li>{ format!("{CMD_OR_CTRL}-Alt-Enter: Replay and Pause") }</li>
             </ul>
 
             <h2>{ "Language" }</h2>

--- a/frontend/app/src/documentation.rs
+++ b/frontend/app/src/documentation.rs
@@ -1,4 +1,4 @@
-use crate::editor_window::CMD_OR_CTRL;
+use crate::editor_window::cmd_or_ctrl;
 use yew::prelude::*;
 
 #[derive(Properties, PartialEq)]
@@ -9,6 +9,7 @@ pub struct DocumentationProps {
 
 #[function_component(Documentation)]
 pub fn documentation(props: &DocumentationProps) -> Html {
+    let cmd_or_ctrl = cmd_or_ctrl();
     let htm = html! {
         <div class="documentation">
             <h1>{ "Quick Reference" }</h1>
@@ -35,9 +36,9 @@ pub fn documentation(props: &DocumentationProps) -> Html {
                 <li>{ "B: Toggle postprocessing (blur)." }</li>
                 <li>{ "Mouse wheel: Zoom." }</li>
                 <li>{ "Mouse click: Select a ship to show debugging info." }</li>
-                <li>{ format!("{CMD_OR_CTRL}-Enter: Execute") }</li>
-                <li>{ format!("{CMD_OR_CTRL}-Shift-Enter: Replay") }</li>
-                <li>{ format!("{CMD_OR_CTRL}-Alt-Enter: Replay and Pause") }</li>
+                <li>{ format!("{cmd_or_ctrl}-Enter: Execute") }</li>
+                <li>{ format!("{cmd_or_ctrl}-Shift-Enter: Replay") }</li>
+                <li>{ format!("{cmd_or_ctrl}-Alt-Enter: Replay and Pause") }</li>
             </ul>
 
             <h2>{ "Language" }</h2>

--- a/frontend/app/src/editor_window.rs
+++ b/frontend/app/src/editor_window.rs
@@ -51,6 +51,12 @@ pub enum Msg {
     CancelDrop(MouseEvent),
 }
 
+pub enum EditorAction {
+    Execute,
+    Replay,
+    ReplayPaused,
+}
+
 #[derive(Properties, Clone, PartialEq)]
 pub struct EditorWindowProps {
     pub host: web_sys::Element,

--- a/frontend/app/src/editor_window.rs
+++ b/frontend/app/src/editor_window.rs
@@ -319,7 +319,6 @@ impl Component for EditorWindow {
             .props()
             .on_editor_action
             .reform(|_| "oort-replay-paused".to_string());
-        let cmd_or_ctrl = if is_mac() { "Cmd" } else { "Ctrl" };
 
         create_portal(
             html! {
@@ -330,17 +329,17 @@ impl Component for EditorWindow {
                     <div class="run_button"><span
                         onclick={run_cb}
                         class="material-symbols-outlined"
-                        title={format!("Execute ({cmd_or_ctrl}-Enter)")}
+                        title={format!("Execute ({CMD_OR_CTRL}-Enter)")}
                     >{ "play_circle" }</span></div>
                     <div class="replay_button"><span
                         onclick={replay_cb}
                         class="material-symbols-outlined"
-                        title={format!("Replay ({cmd_or_ctrl}-Shift-Enter)")}
+                        title={format!("Replay ({CMD_OR_CTRL}-Shift-Enter)")}
                     >{ "replay" }</span></div>
                     <div class="replay_button_paused"><span
                         onclick={replay_paused_cb}
                         class="material-symbols-outlined"
-                        title={format!("Replay paused ({cmd_or_ctrl}-Shift-Enter)")}
+                        title={format!("Replay paused ({CMD_OR_CTRL}-Alt-Enter)")}
                     >{ "autopause" }</span></div>
                     <form>
                         <div class="drop_target display_none" ref={self.drop_target_ref.clone()}>
@@ -625,7 +624,9 @@ impl Completer {
     }
 }
 
-fn is_mac() -> bool {
+pub static CMD_OR_CTRL: &str = if is_mac() { "Cmd" } else { "Ctrl" };
+
+pub fn is_mac() -> bool {
     gloo_utils::window()
         .navigator()
         .app_version()

--- a/frontend/app/src/editor_window.rs
+++ b/frontend/app/src/editor_window.rs
@@ -320,6 +320,8 @@ impl Component for EditorWindow {
             .on_editor_action
             .reform(|_| "oort-replay-paused".to_string());
 
+        let cmd_or_ctrl = cmd_or_ctrl();
+
         create_portal(
             html! {
                 <>
@@ -329,17 +331,17 @@ impl Component for EditorWindow {
                     <div class="run_button"><span
                         onclick={run_cb}
                         class="material-symbols-outlined"
-                        title={format!("Execute ({CMD_OR_CTRL}-Enter)")}
+                        title={format!("Execute ({cmd_or_ctrl}-Enter)")}
                     >{ "play_circle" }</span></div>
                     <div class="replay_button"><span
                         onclick={replay_cb}
                         class="material-symbols-outlined"
-                        title={format!("Replay ({CMD_OR_CTRL}-Shift-Enter)")}
+                        title={format!("Replay ({cmd_or_ctrl}-Shift-Enter)")}
                     >{ "replay" }</span></div>
                     <div class="replay_button_paused"><span
                         onclick={replay_paused_cb}
                         class="material-symbols-outlined"
-                        title={format!("Replay paused ({CMD_OR_CTRL}-Alt-Enter)")}
+                        title={format!("Replay paused ({cmd_or_ctrl}-Alt-Enter)")}
                     >{ "autopause" }</span></div>
                     <form>
                         <div class="drop_target display_none" ref={self.drop_target_ref.clone()}>
@@ -624,7 +626,13 @@ impl Completer {
     }
 }
 
-pub static CMD_OR_CTRL: &str = if is_mac() { "Cmd" } else { "Ctrl" };
+pub fn cmd_or_ctrl() -> String {
+    if is_mac() {
+        "Cmd".to_string()
+    } else {
+        "Ctrl".to_string()
+    }
+}
 
 pub fn is_mac() -> bool {
     gloo_utils::window()

--- a/frontend/app/src/editor_window.rs
+++ b/frontend/app/src/editor_window.rs
@@ -340,7 +340,7 @@ impl Component for EditorWindow {
                     <div class="replay_button_paused"><span
                         onclick={replay_paused_cb}
                         class="material-symbols-outlined"
-                        title={"Replay paused"}
+                        title={format!("Replay paused ({cmd_or_ctrl}-Shift-Enter)")}
                     >{ "autopause" }</span></div>
                     <form>
                         <div class="drop_target display_none" ref={self.drop_target_ref.clone()}>
@@ -427,7 +427,15 @@ impl Component for EditorWindow {
                     ),
                 );
 
-                add_action("oort-replay-paused", "Replay paused", None);
+                add_action(
+                    "oort-replay-paused",
+                    "Replay paused",
+                    Some(
+                        monaco::sys::KeyMod::ctrl_cmd() as u32
+                            | monaco::sys::KeyMod::alt() as u32
+                            | monaco::sys::KeyCode::Enter as u32,
+                    ),
+                );
 
                 add_action("oort-restore-initial-code", "Restore initial code", None);
 

--- a/frontend/app/src/game.rs
+++ b/frontend/app/src/game.rs
@@ -1,8 +1,7 @@
 use crate::codestorage;
 use crate::compiler_output_window::CompilerOutputWindow;
 use crate::documentation::Documentation;
-use crate::editor_window::EditorAction;
-use crate::editor_window::EditorWindow;
+use crate::editor_window::{EditorAction, EditorWindow};
 use crate::gtag;
 use crate::js;
 use crate::leaderboard::Leaderboard;

--- a/frontend/app/src/game.rs
+++ b/frontend/app/src/game.rs
@@ -593,13 +593,18 @@ impl Component for Game {
             })
         };
 
+        let on_replay_pause_cb = context.link().callback(|_| Msg::EditorAction {
+            team: 0,
+            action: "oort-replay-paused".to_string(),
+        });
+
         html! {
         <>
             <Toolbar scenario_name={context.props().scenario.clone()} {select_scenario_cb} show_feedback_cb={show_feedback_cb.clone()} />
             <Welcome host={welcome_window_host} show_feedback_cb={show_feedback_cb.clone()} select_scenario_cb={select_scenario_cb2} />
             <EditorWindow host={editor_window0_host} editor_link={editor0_link} on_editor_action={on_editor0_action} team=0 />
             <EditorWindow host={editor_window1_host} editor_link={editor1_link} on_editor_action={on_editor1_action} team=1 />
-            <SimulationWindow host={simulation_window_host} {on_simulation_finished} {register_link} {version} canvas_ref={self.simulation_canvas_ref.clone()} />
+            <SimulationWindow host={simulation_window_host} {on_simulation_finished} {register_link} on_replay_pause={on_replay_pause_cb} {version} canvas_ref={self.simulation_canvas_ref.clone()} />
             <Documentation host={documentation_window_host} {show_feedback_cb} />
             <CompilerOutputWindow host={compiler_output_window_host} {compiler_errors} />
             <LeaderboardWindow host={leaderboard_window_host} scenario_name={context.props().scenario.clone()} {play_cb} />

--- a/frontend/app/src/game.rs
+++ b/frontend/app/src/game.rs
@@ -1,6 +1,7 @@
 use crate::codestorage;
 use crate::compiler_output_window::CompilerOutputWindow;
 use crate::documentation::Documentation;
+use crate::editor_window::EditorAction;
 use crate::editor_window::EditorWindow;
 use crate::gtag;
 use crate::js;
@@ -593,9 +594,13 @@ impl Component for Game {
             })
         };
 
-        let on_replay_pause_cb = context.link().callback(|_| Msg::EditorAction {
+        let on_simulation_editor_action_cb = context.link().callback(|action| Msg::EditorAction {
             team: 0,
-            action: "oort-replay-paused".to_string(),
+            action: match action {
+                EditorAction::Execute => "oort-execute".to_string(),
+                EditorAction::Replay => "oort-replay".to_string(),
+                EditorAction::ReplayPaused => "oort-replay-paused".to_string(),
+            },
         });
 
         html! {
@@ -604,7 +609,7 @@ impl Component for Game {
             <Welcome host={welcome_window_host} show_feedback_cb={show_feedback_cb.clone()} select_scenario_cb={select_scenario_cb2} />
             <EditorWindow host={editor_window0_host} editor_link={editor0_link} on_editor_action={on_editor0_action} team=0 />
             <EditorWindow host={editor_window1_host} editor_link={editor1_link} on_editor_action={on_editor1_action} team=1 />
-            <SimulationWindow host={simulation_window_host} {on_simulation_finished} {register_link} on_replay_pause={on_replay_pause_cb} {version} canvas_ref={self.simulation_canvas_ref.clone()} />
+            <SimulationWindow host={simulation_window_host} {on_simulation_finished} {register_link} on_editor_action={on_simulation_editor_action_cb} {version} canvas_ref={self.simulation_canvas_ref.clone()} />
             <Documentation host={documentation_window_host} {show_feedback_cb} />
             <CompilerOutputWindow host={compiler_output_window_host} {compiler_errors} />
             <LeaderboardWindow host={leaderboard_window_host} scenario_name={context.props().scenario.clone()} {play_cb} />

--- a/frontend/app/src/simulation_window.rs
+++ b/frontend/app/src/simulation_window.rs
@@ -1,4 +1,4 @@
-use crate::ui::UI;
+use crate::{editor_window::EditorAction, ui::UI};
 use gloo_render::{request_animation_frame, AnimationFrame};
 use oort_simulation_worker::SimAgent;
 use oort_simulator::{scenario, simulation::Code, snapshot::Snapshot};
@@ -30,7 +30,7 @@ pub struct SimulationWindowProps {
     pub host: web_sys::Element,
     pub on_simulation_finished: Callback<Snapshot>,
     pub register_link: Callback<Scope<SimulationWindow>>,
-    pub on_replay_pause: Callback<()>,
+    pub on_editor_action: Callback<EditorAction>,
     pub version: String,
     pub canvas_ref: NodeRef,
 }
@@ -86,7 +86,7 @@ impl Component for SimulationWindow {
                 self.nonce = rand::thread_rng().gen();
                 self.ui = Some(Box::new(UI::new(
                     context.link().callback(|_| Msg::RequestSnapshot),
-                    context.props().on_replay_pause.clone(),
+                    context.props().on_editor_action.clone(),
                     seed,
                     self.nonce,
                     context.props().version.clone(),

--- a/frontend/app/src/simulation_window.rs
+++ b/frontend/app/src/simulation_window.rs
@@ -30,6 +30,7 @@ pub struct SimulationWindowProps {
     pub host: web_sys::Element,
     pub on_simulation_finished: Callback<Snapshot>,
     pub register_link: Callback<Scope<SimulationWindow>>,
+    pub on_replay_pause: Callback<()>,
     pub version: String,
     pub canvas_ref: NodeRef,
 }
@@ -85,6 +86,7 @@ impl Component for SimulationWindow {
                 self.nonce = rand::thread_rng().gen();
                 self.ui = Some(Box::new(UI::new(
                     context.link().callback(|_| Msg::RequestSnapshot),
+                    context.props().on_replay_pause.clone(),
                     seed,
                     self.nonce,
                     context.props().version.clone(),

--- a/frontend/app/src/ui/mod.rs
+++ b/frontend/app/src/ui/mod.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use web_sys::{Element, HtmlCanvasElement};
 use yew::NodeRef;
 
-use crate::editor_window::EditorAction;
+use crate::editor_window::{is_mac, EditorAction};
 
 const ZOOM_SPEED: f32 = 0.02;
 const MIN_ZOOM: f32 = 5e-6;
@@ -184,20 +184,21 @@ impl UI {
             self.paused = true;
             self.single_steps += 1;
         }
-        // Docs for key strings: https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
 
-        let execute_set = vec!["Enter"];
-        self.check_both_keysets(execute_set, |ui| {
+        // Docs for key strings: https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
+        let ctrl_cmd = if is_mac() { "Meta" } else { "Control" };
+        let execute_set = vec![ctrl_cmd, "Enter"];
+        self.on_key_set_match(execute_set, |ui| {
             ui.on_editor_action.emit(EditorAction::Execute)
         });
 
-        let replay_set = vec!["Shift", "Enter"];
-        self.check_both_keysets(replay_set, |ui| {
+        let replay_set = vec![ctrl_cmd, "Shift", "Enter"];
+        self.on_key_set_match(replay_set, |ui| {
             ui.on_editor_action.emit(EditorAction::Replay)
         });
 
-        let replay_paused_set = vec!["Alt", "Enter"];
-        self.check_both_keysets(replay_paused_set, |ui| {
+        let replay_paused_set = vec![ctrl_cmd, "Alt", "Enter"];
+        self.on_key_set_match(replay_paused_set, |ui| {
             ui.on_editor_action.emit(EditorAction::ReplayPaused)
         });
 
@@ -377,19 +378,6 @@ impl UI {
             for key in set {
                 self.keys_ignored.insert(key.to_string());
             }
-        }
-    }
-
-    fn check_both_keysets<F>(&mut self, set: Vec<&str>, callback: F)
-    where
-        F: Fn(&mut Self) -> () + std::marker::Copy,
-    {
-        let cmd_and_ctrl_keysets = vec![
-            [vec!["Meta"], set.clone()].concat(),
-            [vec!["Control"], set.clone()].concat(),
-        ];
-        for combo_set in cmd_and_ctrl_keysets {
-            self.on_key_set_match(combo_set, callback);
         }
     }
 


### PR DESCRIPTION
In this PR:
- Users can now replay and pause using the key combo ctrl+alt+enter with the editor selected.
- When the simulator is selected, users can execute with ctrl+enter, replay with ctrl+shift+enter and replay and pause with ctrl+alt+enter

Motivation:
- When working in an external editor, users still needed in-game editor to be visible to run the above actions. This allows users working in an external editor to collapse the in-game editor and free up some screen real estate.

<img width="1632" alt="Screenshot 2023-11-08 at 1 58 44 AM" src="https://github.com/rlane/oort3/assets/5561501/180a8ad8-f592-402e-9d30-5ecba6708804">
