### PR TITLE
Make formatting of times in battle binary easier to read

### DIFF
--- a/tools/src/bin/battle.rs
+++ b/tools/src/bin/battle.rs
@@ -91,15 +91,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             results.draws.len(),
             &results.draws[..].iter().take(n).collect::<Vec<_>>()
         );
-        println!(
-            "  Times: {} {:?}",
-            results.times.len(),
-            &results.times[..]
-                .iter()
-                .take(n)
-                .map(|t| format!("{:.3}", t))
-                .collect::<Vec<_>>()
-        );
+        print!("  Times: [");
+        for (i, time) in results.times.iter().enumerate().take(n) {
+            if i > 0 {
+                print!(", ");
+            }
+            print!("{}: {:.3}", i, time);
+        }
+        println!("]");
         println!(
             "  Average time: {:.3}",
             results.times.iter().sum::<f64>() / results.times.len() as f64


### PR DESCRIPTION
From
```  Times: ["4.267", "3.383", "3.800", "3.167", "4.017", "3.633", "3.367", "4.550", "3.700", "3.983"]```
To
```  Times: [0: 4.267, 1: 3.383, 2: 3.800, 3: 3.167, 4: 4.017, 5: 3.633, 6: 3.367, 7: 4.550, 8: 3.700, 9: 3.983]```