### PR TITLE
Proved that scan already returns the location on the current tick

### DIFF
--- a/shared/api/src/lib.rs
+++ b/shared/api/src/lib.rs
@@ -712,6 +712,7 @@ mod api {
     }
 
     /// Returns the radar contact with the highest signal strength.
+    /// Position and velocity are from the previous tick
     pub fn scan() -> Option<ScanResult> {
         if read_system_state(SystemState::RadarContactFound) == 0.0 {
             return None;

--- a/shared/api/src/lib.rs
+++ b/shared/api/src/lib.rs
@@ -712,7 +712,6 @@ mod api {
     }
 
     /// Returns the radar contact with the highest signal strength.
-    /// Position and velocity are from the previous tick
     pub fn scan() -> Option<ScanResult> {
         if read_system_state(SystemState::RadarContactFound) == 0.0 {
             return None;

--- a/shared/simulator/src/radar.rs
+++ b/shared/simulator/src/radar.rs
@@ -1020,7 +1020,7 @@ mod test {
 
     #[test]
     fn test_ship_get_current_ship_position() {
-        // At the time of writing, scan() was returning scan results from the previous tick
+        // At the time of writing, we thought scan() was returning scan results from the previous tick
         // which meant that target position could be innaccurate if the scanned object was moving
         let mut sim = Simulation::new("test", 0, &[Code::None, Code::None]);
 


### PR DESCRIPTION
We thought that `scan()` was returning results from the previous tick. This PR introduces a test proving that, that's not the case.