### PR TITLE
Crash on pause and timeline focus capture fixed

### DIFF
--- a/frontend/app/src/simulation_window.rs
+++ b/frontend/app/src/simulation_window.rs
@@ -212,6 +212,21 @@ impl Component for SimulationWindow {
             Msg::TimelineEvent(slider_value)
         });
 
+        // We need a separate callback for the onchange event because the input event is not fired on release
+        // which causes the timeline to remain focused which captures all key events
+        let timeline_on_change_cb = context.link().callback(|event: Event| {
+            let target = event
+                .target()
+                .expect("Event should have a target when dispatched");
+
+            let slider_value = target
+                .unchecked_into::<HtmlInputElement>()
+                .value_as_number()
+                .round() as usize;
+
+            Msg::TimelineEvent(slider_value)
+        });
+
         create_portal(
             html! {
                 <>
@@ -225,7 +240,7 @@ impl Component for SimulationWindow {
                         onpointerup={pointer_event_cb.clone()}
                         onpointerdown={pointer_event_cb}
                         onblur={blur_event_cb} />
-                    <input ref={self.timeline_ref.clone()} type="range" oninput={timeline_event_cb} class="slider"/>
+                    <input ref={self.timeline_ref.clone()} type="range" oninput={timeline_event_cb} onchange={timeline_on_change_cb} class="slider"/>
                     <div class="status" ref={self.status_ref.clone()} />
                     <div class="picked">
                         <pre ref={self.picked_ref.clone()}></pre>

--- a/frontend/app/src/ui/mod.rs
+++ b/frontend/app/src/ui/mod.rs
@@ -185,7 +185,8 @@ impl UI {
             self.steps_forward = 0;
             self.steps_backward = 0;
             self.is_buffering = false;
-            self.last_render_time = instant::Instant::now();
+            // No time should elapse while pausing
+            self.last_render_time = now;
         }
         if self.keys_pressed.contains("KeyN") {
             self.paused = true;
@@ -390,7 +391,6 @@ impl UI {
 
         self.frame_timer
             .end((instant::Instant::now() - self.start_time).as_millis() as f64);
-
         self.keys_pressed.clear();
     }
 


### PR DESCRIPTION
Couple of late bug fixes for the timeline. 
- There was an issue where the app would crash when pausing due to an invalid duration subtraction
- If you clicked on the timeline rather than dragging it, the timeline would capture focus