### PR TITLE
draw_text improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,11 +516,14 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
+ "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -662,9 +665,9 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "cmake"
-version = "0.1.50"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
@@ -1284,6 +1287,12 @@ dependencies = [
  "redox_syscall 0.3.5",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "firestore"
@@ -2152,9 +2161,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -4028,6 +4037,12 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"

--- a/frontend/renderer/src/text_renderer.rs
+++ b/frontend/renderer/src/text_renderer.rs
@@ -191,10 +191,22 @@ void main() {
                 (projected.x + 1.0) * screen_width / 2.0,
                 (projected.y + 1.0) * screen_height / 2.0
             ];
-            let mut pos = vector![projected_pixels.x.floor(), projected_pixels.y.floor()];
+            let initial_x = projected_pixels.x.floor();
+            let mut pos = vector![initial_x, projected_pixels.y.floor()];
             let color = color::from_u24(text.color);
+                log::info!("text: {}", text.length);
             for i in 0..text.length {
-                let idx = (text.text[i as usize] as usize - 32).clamp(0, FONT_ROWS * FONT_COLS - 1);
+                let char_id = (text.text[i as usize]) as usize;
+
+
+                // Support for newline characters: if we're a \n (code 10), adjust the col 
+                if char_id == 10 {
+                    pos.y -= (FONT_GLYPH_SIZE as f32 + 1.0) * scale;
+                    pos.x = initial_x;
+                    continue;
+                }
+
+                let idx = char_id.saturating_sub(32).clamp(0, FONT_ROWS * FONT_COLS - 1);
                 let row = FONT_ROWS - idx / FONT_COLS - 1;
                 let col = idx % FONT_COLS;
 

--- a/shared/api/src/lib.rs
+++ b/shared/api/src/lib.rs
@@ -377,7 +377,7 @@ pub struct Text {
     pub y: f64,
     pub color: u32,
     pub length: u8,
-    pub text: [u8; 11],
+    pub text: [u8; 27],
 }
 
 /// Message sent and received on the radio.
@@ -420,11 +420,15 @@ pub mod sys {
         // Format is key=value\nkey=value\n... ending with a null byte.
         unsafe {
             let environment = ptr::addr_of!(ENVIRONMENT);
-            let n = (*environment)
+
+            let env_arr: &[u8] = &*environment;
+
+            let n = env_arr
                 .iter()
                 .position(|&c| c == 0)
                 .unwrap_or((*environment).len());
-            std::str::from_utf8(&(*environment)[..n])
+
+            std::str::from_utf8(&env_arr[..n])
                 .expect("Failed to convert environment to string")
         }
     }
@@ -1221,7 +1225,7 @@ pub mod dbg {
         let _ = std::fmt::write(&mut text, args);
         let buf = unsafe { &mut *ptr::addr_of_mut!(DRAWN_TEXT_BUFFER) };
         // TODO handle longer text
-        let mut text_buf = [0u8; 11];
+        let mut text_buf = [0u8; 27];
         text_buf
             .iter_mut()
             .zip(text.bytes())

--- a/shared/simulator/src/scenario/planetary_defense.rs
+++ b/shared/simulator/src/scenario/planetary_defense.rs
@@ -122,7 +122,7 @@ impl Scenario for PlanetaryDefense {
                 "POP {:.1}B",
                 10.0 * sim.ship(planet_handle).data().health / Self::PLANET_HEALTH
             );
-            let mut buf = [0u8; 11];
+            let mut buf = [0u8; 27];
             for (i, b) in s.bytes().enumerate() {
                 buf[i] = b;
             }


### PR DESCRIPTION
# Overview

Implemented the following trello feature requests:
- Increased the maximum text size from 11 to 27 (somewhat arbitrary, let me know if you'd rather change this so something else) [Trello Link](https://trello.com/c/cZx0SuXG/312-longer-limit-for-drawtext)
- Added support for newline character in draw_text [Trello Link](https://trello.com/c/HoOg3QA6/314-support-newlines-in-drawtext)

Other changes:
- Fixed runtime overflow error if providing ascii characters < 10 in draw_text

# Notes 

I was experiencing a runtime panic from an unsigned overflow from the following line when inputting `\n` (ascii code 10):

```rs
let idx = (text.text[i as usize] as usize - 32).clamp(0, FONT_ROWS * FONT_COLS - 1);
```

Interestingly, this seemed to only be a problem in my local development environment. I'm not sure if this is a case of different compile flags (or compiler version), but I'd be interested in knowing.

I was also getting a `implicit autoref creates a reference to the dereference of a raw pointer` compiler error in the `from_utf` call shown in the diff below. I assume this is also a result in different flags or later rust version, but replaced it with the recommended approach from the Rust documentation.







 

# Example

<img width="539" height="235" alt="image" src="https://github.com/user-attachments/assets/0bc95b48-3725-4d96-b4b0-660232664834" />


Code:
```rs
use oort_api::prelude::*;

pub struct Ship {}

impl Ship {
    pub fn new() -> Ship {
        Ship {}
    }

    pub fn tick(&mut self) {
        draw_text!(vec2(0., 10.), 0xFF00000, "Line 1\nLine 2\nLine 3\nLine 4");
    }
}
```

# Testing 

I couldn't find anything in the README regarding testing, so I only ran `cargo test`. All tests passing, but let me know if there are any additional tools I should run.


